### PR TITLE
#7 feat login and routing

### DIFF
--- a/PoLyBear2/react-toy/src/components/App.js
+++ b/PoLyBear2/react-toy/src/components/App.js
@@ -1,9 +1,16 @@
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Login from './Login';
+import Roomlist from './Roomlist';
 
 function App() {
   return (
     <div class='flex justify-center items-center h-screen'>
-      <Login></Login>
+      <BrowserRouter>
+        <Routes>
+          <Route path='/' element={<Login></Login>}></Route>
+          <Route path='/list' element={<Roomlist></Roomlist>}></Route>
+        </Routes>
+      </BrowserRouter>
     </div>
   );
 }

--- a/PoLyBear2/react-toy/src/components/Login.jsx
+++ b/PoLyBear2/react-toy/src/components/Login.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 const Login = () => {
   const [inputId, setInputId] = useState('');
@@ -6,8 +7,9 @@ const Login = () => {
 
   const [userData, setUserData] = useState([]);
 
+  const navigate = useNavigate();
+
   useEffect(() => {
-    console.log('시작');
     const fetchData = async () => {
       try {
         const response = await fetch('/data/user.json', {
@@ -16,7 +18,6 @@ const Login = () => {
             Accept: 'application/json',
           },
         });
-        console.log(response);
         const jsonData = await response.json();
         setUserData(jsonData);
       } catch (error) {
@@ -38,6 +39,7 @@ const Login = () => {
   const handleLogin = (e) => {
     if (inputId === userData.id && inputPw === userData.password) {
       alert('로그인 성공');
+      navigate('/list');
     } else {
       alert('로그인 실패');
     }

--- a/PoLyBear2/react-toy/src/components/Roomlist.jsx
+++ b/PoLyBear2/react-toy/src/components/Roomlist.jsx
@@ -1,0 +1,34 @@
+import React, { useState, useEffect } from 'react';
+import Roomcard from './card/Roomcard';
+
+const Roomlist = () => {
+  const [rooms, setRooms] = useState([]);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await fetch('/data/rooms.json', {
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+        });
+        const jsonData = await response.json();
+        setRooms(jsonData);
+        console.log(rooms);
+      } catch (error) {
+        console.error('Error fetching data:', error);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  return (
+    <>
+      <Roomcard></Roomcard>
+    </>
+  );
+};
+
+export default Roomlist;

--- a/PoLyBear2/react-toy/src/components/card/Roomcard.jsx
+++ b/PoLyBear2/react-toy/src/components/card/Roomcard.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+const Roomcard = () => {
+  return (
+    <>
+      <div class='w-full max-w-sm bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700'>
+        <div class='flex justify-end px-4 pt-4'>
+          <button
+            id='dropdownButton'
+            class='inline-block text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700 focus:ring-4 focus:outline-none focus:ring-gray-200 dark:focus:ring-gray-700 rounded-lg text-sm p-1.5'
+            type='button'></button>
+        </div>
+        <div class='flex flex-col items-center pb-10'>
+          <h5 class='mb-1 text-xl font-medium text-gray-900 dark:text-white'>
+            title
+          </h5>
+          <h6 class='mb-1 text-l font-medium text-gray-900 dark:text-white'>
+            username
+          </h6>
+          <span class='text-sm text-gray-500 dark:text-gray-400'>tier</span>
+          <div class='flex mt-4 space-x-3 md:mt-6'>
+            <a
+              href='#'
+              class='inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800'>
+              입장
+            </a>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default Roomcard;


### PR DESCRIPTION
### 7
[issue-7 로그인 기능 및 페이지 라우팅 ](https://github.com/GunBros/ReactPracticeToy/issues/7) 
    

### 개요(간단한 작업 내용 설명)
로그인 버튼 클릭 시 읽어온 user.json과 비교하여 같을 시 '/list' 라우팅으로 방 목록 페이지로 넘어갈 수 있음
### 스크린 샷 및 화면
![image](https://github.com/GunBros/ReactPracticeToy/assets/109647226/5c857225-8bf1-427c-9cf7-5a09d409e270)

### 구현한 내용 로직 설명 - Backend

### 작업한 내용
라우팅으로 넘어간 '/list'는 json 파일을 읽어 올 RoomList.jsx과 방 목록 컴포넌트 Roomcard.jsx로 구성
커밋 내용 - 커밋 링크
